### PR TITLE
Add an example of combining Map() and Bind() to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,33 @@ Try<int> t2 = t1.Map(v1 =>
     return v1.Value + 10;
 });
 ```
+
+### Short Circuit failure paths
+
+A powerful way of using this monad is by combining `Map()` and `Bind()`. Aside from making the code more fluent, the execution path will short circuit and return as soon as a failure state is encountered:
+
+```C#
+Try<int> tryResult = Increment1(1)
+   .Bind(Increment2)
+   .Map(Increment3);
+
+string result = tryResult.Match(
+   exception => $"Failed: {exception.Message}",
+   value => $"Passed: {value}");
+
+private static Try<int> Increment1(int x)
+{
+   return Try.Create(() => x + 1);
+}
+
+private static Try<int> Increment2(int x)
+{
+   return Try.FromException<int>(new Exception("Failed!"));
+}
+
+// This method will never get executed since the previous method threw an exception
+private static int Increment3(int x)
+{
+   return x + 3;
+}
+```


### PR DESCRIPTION
With this monad, the most common use-case (at least for me) is combining `Map()` and `Bind()`. I thought it would be nice to add a clear example of doing this in the README to show how and why you'd want to combine the 2.