### PR TITLE
Add a version of Match that doesn't return anything and accepts an Action<T>

### DIFF
--- a/src/Nito.Try/Try(T).cs
+++ b/src/Nito.Try/Try(T).cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Runtime.ExceptionServices;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Nito
@@ -105,10 +103,29 @@ namespace Nito
         }
 
         /// <summary>
-        /// Executes an action for the wrapped exception or value.
+        /// Executes a method (Action) for the wrapped exception or value.
         /// </summary>
-        /// <param name="whenException">The action to execute if this instance is an exception.</param>
-        /// <param name="whenValue">The action to execute if this instance is a value.</param>
+        /// <param name="whenException">The method to execute if this instance is an exception.</param>
+        /// <param name="whenValue">The method to execute if this instance is a value.</param>
+        public void Match(Action<Exception> whenException, Action<T> whenValue)
+        {
+            _ = whenException ?? throw new ArgumentNullException(nameof(whenException));
+            _ = whenValue ?? throw new ArgumentNullException(nameof(whenValue));
+            if (IsException)
+            {
+                whenException(_exception!);
+            }
+            else
+            {
+                whenValue(_value);
+            }
+        }
+
+        /// <summary>
+        /// Executes a method (Func) for the wrapped exception or value.
+        /// </summary>
+        /// <param name="whenException">The method to execute if this instance is an exception.</param>
+        /// <param name="whenValue">The method to execute if this instance is a value.</param>
         public TResult Match<TResult>(Func<Exception, TResult> whenException, Func<T, TResult> whenValue)
         {
             _ = whenException ?? throw new ArgumentNullException(nameof(whenException));

--- a/test/UnitTests/TryUnitTests.cs
+++ b/test/UnitTests/TryUnitTests.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using Nito;
 using Xunit;
@@ -136,6 +133,31 @@ namespace UnitTests
         }
 
         [Fact]
+        public void Match_ForValue_OnlyExecutesValueAction()
+        {
+            var exceptionInvoked = false;
+            Exception exception = null;
+            var valueInvoked = false;
+            int? value = 0;
+            var t = Try.FromValue(13);
+            t.Match(
+                ex =>
+                {
+                    exceptionInvoked = true;
+                    exception = ex;
+                },
+                v =>
+                {
+                    valueInvoked = true;
+                    value = v;
+                });
+            Assert.False(exceptionInvoked);
+            Assert.True(valueInvoked);
+            Assert.Equal(13, value);
+            Assert.Null(exception);
+        }
+
+        [Fact]
         public void Match_ForException_OnlyExecutesExceptionFunc()
         {
             var exceptionInvoked = false;
@@ -155,6 +177,29 @@ namespace UnitTests
                     valueInvoked = true;
                     value = v;
                     return 5;
+                });
+            Assert.True(exceptionInvoked);
+            Assert.False(valueInvoked);
+            Assert.IsType<InvalidOperationException>(exception);
+            Assert.Equal("test", exception.Message);
+        }
+
+        [Fact]
+        public void Match_ForException_OnlyExecutesExceptionAction()
+        {
+            var exceptionInvoked = false;
+            Exception exception = null;
+            var valueInvoked = false;
+            var t = Try.FromException<int>(new InvalidOperationException("test"));
+            t.Match(
+                ex =>
+                {
+                    exceptionInvoked = true;
+                    exception = ex;
+                },
+                v =>
+                {
+                    valueInvoked = true;
                 });
             Assert.True(exceptionInvoked);
             Assert.False(valueInvoked);


### PR DESCRIPTION
Often times you (at least I) only want to perform an Action when pattern matching on a `TryResult`. For example you may want to just log something. In my opinion it would be helpful to add this overload to `Match`.